### PR TITLE
Fix pagination links when using non standard ports

### DIFF
--- a/src/CommunityStoreApi/Api/Order/OrdersController.php
+++ b/src/CommunityStoreApi/Api/Order/OrdersController.php
@@ -133,20 +133,18 @@ class OrdersController extends ApiController
             }
             $orderList->setOrderIDs($orderIDs);
         }
-        
+
         $factory = new PaginationFactory($this->app->make(Request::class));
         $paginator = $factory->createPaginationObject($orderList);
         $orders = $paginator->getCurrentPageResults();
 
         $fanta = new PagerfantaPaginatorAdapter($paginator, function (int $page)  {
-            $path = $this->request->getUri();
-            $pathInfo = parse_url($path);
-            $queryString = $pathInfo['query'];
+            $url = $this->request->getUri();
+            $queryString = parse_url($url, PHP_URL_QUERY);
             parse_str($queryString, $queryArray);
             $queryArray['page'] = $page;
-            $newQueryStr = http_build_query($queryArray);
 
-            return $pathInfo['scheme'] . '://' . $pathInfo['host']  . $pathInfo['path'] . '?' . $newQueryStr;
+            return preg_split('/[\?#]/', $url)[0] . '?' . http_build_query($queryArray);
         });
 
         $resource = new Collection($orders, new OrderTransformer);

--- a/src/CommunityStoreApi/Api/Product/ProductsController.php
+++ b/src/CommunityStoreApi/Api/Product/ProductsController.php
@@ -144,14 +144,12 @@ class ProductsController extends ApiController
         $products = $paginator->getCurrentPageResults();
 
         $fanta = new PagerfantaPaginatorAdapter($paginator, function (int $page)  {
-            $path = $this->request->getUri();
-            $pathInfo = parse_url($path);
-            $queryString = $pathInfo['query'];
+            $url = $this->request->getUri();
+            $queryString = parse_url($url, PHP_URL_QUERY);
             parse_str($queryString, $queryArray);
             $queryArray['page'] = $page;
-            $newQueryStr = http_build_query($queryArray);
 
-            return $pathInfo['scheme'] . '://' . $pathInfo['host']  . $pathInfo['path'] . '?' . $newQueryStr;
+            return preg_split('/[\?#]/', $url)[0] . '?' . http_build_query($queryArray);
         });
 
         $resource = new Collection($products, new ProductTransformer);


### PR DESCRIPTION
When we build the pagination next/previous links, we don't add the port.

For example, for requests like:

```
http://localhost:8080/cs/api/v1/orders?fromDate=2022-02-24
```

The "next" pagination is
```
http://localhost/cs/api/v1/orders?fromDate=2022-02-24&page=2
```

(please remark the missing `:8080`)

Let's fix this issue.