### PR TITLE
Add the system time zone to the config response

### DIFF
--- a/src/CommunityStoreApi/Api/Config/ConfigController.php
+++ b/src/CommunityStoreApi/Api/Config/ConfigController.php
@@ -49,6 +49,9 @@ class ConfigController extends ApiController
             'community_store_api' => [
                 'version' => $csApiPackage->getPackageVersion(),
             ],
+            'system' => [
+                'time_zone' => (string) date_default_timezone_get(),
+            ],
         ];
 
         return $this->transform($config, new ConfigTransformer());


### PR DESCRIPTION
When performing queries that involve dates, it may be useful to know the default time zone defined on the Community Store server